### PR TITLE
Improve term matching in AvoidSpecificTermsInModuleNames check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You just need to add the checks you want in your `.credo.exs` configuration file
 This check will raise an issue if specific terms are found in module names.
 
 ```elixir
-{CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", "Helper", "Helpers"]}
+{CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", ~r/Helpers?/]}
 ```
 
 Suppose you have a `MyApp.ErrorHelpers` module:

--- a/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
+++ b/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
@@ -60,7 +60,7 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames do
     Enum.any?(terms, fn
       term_to_avoid when is_binary(term_to_avoid) -> String.downcase(term_to_avoid) == String.downcase(term)
       %Regex{} = term_to_avoid -> Regex.match?(term_to_avoid, term)
-      term -> raise("The "terms" config expected each term to be a String or Regex, got: #{inspect(term)}")
+      term -> raise(~s(The "terms" config expected each term to be a String or Regex, got: #{inspect(term)}))
     end)
   end
 

--- a/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
+++ b/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
@@ -60,7 +60,7 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames do
     Enum.any?(terms, fn
       term_to_avoid when is_binary(term_to_avoid) -> String.downcase(term_to_avoid) == String.downcase(term)
       %Regex{} = term_to_avoid -> Regex.match?(term_to_avoid, term)
-      _ -> false
+      term -> raise("The "terms" config expected each term to be a String or Regex, got: #{inspect(term)}")
     end)
   end
 

--- a/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
+++ b/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
@@ -44,7 +44,7 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames do
       mod
       |> Enum.flat_map(&Name.split_pascal_case(Atom.to_string(&1)))
       |> Enum.reduce(issues, fn term, acc ->
-        if term in terms do
+        if term_to_avoid?(term, terms) do
           acc ++ [issue_for(issue_meta, Keyword.get(opts, :line), term)]
         else
           acc
@@ -55,6 +55,14 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames do
   end
 
   def traverse(ast, issues, _, _), do: {ast, issues}
+
+  defp term_to_avoid?(term, terms) do
+    Enum.any?(terms, fn
+      term_to_avoid when is_binary(term_to_avoid) -> String.downcase(term_to_avoid) == String.downcase(term)
+      %Regex{} = term_to_avoid -> Regex.match?(term_to_avoid, term)
+      _ -> false
+    end)
+  end
 
   defp issue_for(issue_meta, line_no, trigger) do
     format_issue(

--- a/test/credo_naming/check/warning/avoid_specific_terms_in_module_names_test.exs
+++ b/test/credo_naming/check/warning/avoid_specific_terms_in_module_names_test.exs
@@ -59,4 +59,22 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNamesTest do
     |> to_source_file
     |> assert_issue(@described_check, terms: ["Helpers"])
   end
+
+  test "it should report a violation in a module with mixed case" do
+    """
+    defmodule App.Helper.Error do
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, terms: ["helper"])
+  end
+
+  test "it should report a violation in a module matching a regular expression" do
+    """
+    defmodule App.Helper.Error do
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check, terms: ["Manager", ~r/^helpers?$/i])
+  end
 end

--- a/test/credo_naming/check/warning/avoid_specific_terms_in_module_names_test.exs
+++ b/test/credo_naming/check/warning/avoid_specific_terms_in_module_names_test.exs
@@ -77,4 +77,21 @@ defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNamesTest do
     |> to_source_file
     |> assert_issue(@described_check, terms: ["Manager", ~r/^helpers?$/i])
   end
+
+  #
+  # configuration raising errors
+  #
+
+  test "it should raise an error when a non-String or non-Regex is used as a term" do
+    run_check = fn ->
+      """
+      defmodule App.Helper.Error do
+      end
+      """
+      |> to_source_file
+      |> assert_issue(@described_check, terms: ["Manager", ~r/^helpers?$/i, 42])
+    end
+
+    assert_raise RuntimeError, "The \"terms\" config expected each term to be a String or Regex, got: 42", run_check
+  end
 end


### PR DESCRIPTION
This pull request adds support for two things related to terms matching in the `AvoidSpecificTermsInModuleNames` check:

1. String terms are now case-insensitive
2. A “term to avoid” can now be a regular expression, so instead of having this:
    
    ```elixir
    terms: ["Helper", "Helpers"]
    ```
      
    You can now simple use:
    
    ```elixir
    terms: [~r/^Helpers?$/]
    ```