### PR TITLE
Strip “_test” suffix in duplicate filename

### DIFF
--- a/lib/credo_naming/check/consistency/module_filename.ex
+++ b/lib/credo_naming/check/consistency/module_filename.ex
@@ -127,10 +127,15 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
 
     [shortest_filename | _] = filenames
 
-    # We want to support a `Foo` module in either `lib/foo.ex` or `lib/foo/foo.ex`.
-    duplicated_filename = String.replace(shortest_filename, ~r/\/([^.\/]+)(\..+)$/, "/\\1/\\1\\2")
+    # We want to support a `Foo` module in either `lib/foo.ex` or
+    # `lib/foo/foo.ex`. We also want to strip any `_test` directory suffix
+    # because we might define a `FooTest` module in `test/foo/foo_test.exs`.
+    duplicated_filename =
+      shortest_filename
+      |> String.replace(~r/\/([^.\/]+)(\..+)$/, "/\\1/\\1\\2")
+      |> String.replace(~r/_test\//, "/")
 
-    [duplicated_filename] ++ filenames
+    [duplicated_filename | filenames]
   end
 
   defp merge_filename_parts({[], file_parts}), do: merge_filename_parts({[""], file_parts})

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -43,6 +43,15 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report violation for test root module" do
+    """
+    defmodule BarTest do
+    end
+    """
+    |> to_source_file("test/bar/bar_test.exs")
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report violation for PascalCase nested module" do
     """
     defmodule FooWeb.BarWeb do


### PR DESCRIPTION
Since we allow this:

```elixir
# lib/foo/bar/bar.ex
defmodule Foo.Bar do
  …
end
```

It also makes sense to support this:


```elixir
# test/foo/bar/bar_test.exs
defmodule Foo.BarTest do
  …
end
```

This pull request makes the `CredoNaming.Check.Consistency.ModuleFilename` check handle the `_test` suffix in a special way 😄 