### PR TITLE
Always exclude files named 'stdin' in Consistency.ModuleFilename check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -7,6 +7,7 @@
         included: ["*.exs", "lib/", "test/", "config/"],
         excluded: []
       },
+      requires: ["lib/"],
       checks: [
         {Credo.Check.Consistency.ExceptionNames},
         {Credo.Check.Consistency.LineEndings},
@@ -51,7 +52,9 @@
         {Credo.Check.Warning.UnusedListOperation},
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
-        {Credo.Check.Warning.OperationWithConstantResult}
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames, terms: ["Manager", "Fetcher", "Builder", "Persister", "Serializer", ~r/^Helpers?$/i, ~r/^Utils?$/i]},
+        {CredoNaming.Check.Consistency.ModuleFilename, excluded_paths: ["config", "mix.exs", "priv", "test/support"]}
       ]
     }
   ]

--- a/lib/credo_naming/check/consistency/module_filename.ex
+++ b/lib/credo_naming/check/consistency/module_filename.ex
@@ -44,6 +44,7 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
 
     source_file.filename
     |> String.starts_with?(excluded_paths)
+    |> Kernel.||(source_file.filename === "stdin")
     |> if do
       []
     else

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -132,6 +132,15 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report violation for a file called stdin" do
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("stdin")
+    |> refute_issues(@described_check)
+  end
+
   #
   # cases raising issues
   #

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,6 +19,7 @@ exclude = Keyword.merge([to_be_implemented: true], check_version)
 
 ExUnit.configure(exclude: exclude)
 
+# credo:disable-for-next-line CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames
 defmodule Credo.TestHelper do
   defmacro __using__(_) do
     quote do


### PR DESCRIPTION
Credo has an option to check a file from stdin. When this is the case, the [`source_file.filename` is setted to `stdin`](https://github.com/rrrene/credo/blob/621be41660f168eac1786cc908b75a19885b97cf/lib/credo/sources.ex#L31).

So when we use this option, the `Consistency.ModuleFilename` check cannot do it's job since you don't actually have the filename.

This is a problem with the ElixirLinter extension for VSCode since [the extension pass the file through stdin](https://github.com/iampeterbanjo/vscode-elixir-linter/blob/master/src/credoProvider.ts#L115).

I explicitly check if the filename is stdin instead of checking if it starts with stdin to allow the weird use case where someone could have a folder actually called stdin.