### PR TITLE
Add support for a “valid_filename_callback” option in Consistency.ModuleFilename check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
-language: 'elixir'
+language: "elixir"
 
 matrix:
   include:
-  - elixir: 1.6
-    otp_release: 19.3
-  - elixir: 1.6
-    otp_release: 20.3
-  - elixir: 1.6
-    otp_release: 21.3
-  - elixir: 1.7
-    otp_release: 19.3
-  - elixir: 1.7
-    otp_release: 20.3
-  - elixir: 1.7
-    otp_release: 21.3
-  - elixir: 1.8
-    otp_release: 20.3
-  - elixir: 1.8
-    otp_release: 21.3
+    - elixir: 1.8
+      otp_release: 20.3
+    - elixir: 1.9
+      otp_release: 21.3
+    - elixir: 1.10
+      otp_release: 22.1
 
 script: ./priv/scripts/ci-check.sh

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule CredoNaming.MixProject do
       homepage_url: "https://github.com/mirego/credo_naming",
       docs: [extras: ["README.md"], main: "readme", source_ref: "v#{@version}", source_url: "https://github.com/mirego/credo_naming"],
       package: package(),
-      elixir: "~> 1.6",
+      elixir: "~> 1.8",
       start_permanent: false,
       deps: deps()
     ]

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -141,6 +141,23 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report violation for a custom filename callback" do
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("lib/foo/dont_care.ex")
+    |> refute_issues(@described_check,
+      valid_filename_callback: fn filename, _module_name, _opts ->
+        if filename == "lib/foo/dont_care.ex" do
+          {true, []}
+        else
+          {false, []}
+        end
+      end
+    )
+  end
+
   #
   # cases raising issues
   #
@@ -205,5 +222,22 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     """
     |> to_source_file("lib/foo/bar.ex")
     |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation with custom filename callback" do
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("lib/foo/bar.ex")
+    |> assert_issue(@described_check,
+      valid_filename_callback: fn _filename, module_name, _opts ->
+        if module_name == "Foo.Bar" do
+          {false, ["lib/foo/bar_yes.ex"]}
+        else
+          {true, []}
+        end
+      end
+    )
   end
 end


### PR DESCRIPTION
As mentioned in #3, the naming conventions used in by the `CredoNaming.Check.Consistency.ModuleFilename` are opinionated. This new `valid_filename_callback` option makes it possible to customize them.