### PR TITLE
Add Credo 1.4-specific features

### DIFF
--- a/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
+++ b/lib/credo_naming/check/warning/avoid_specific_terms_in_module_names.ex
@@ -1,38 +1,42 @@
 defmodule CredoNaming.Check.Warning.AvoidSpecificTermsInModuleNames do
-  @moduledoc false
+  use Credo.Check,
+    base_priority: :low,
+    tags: [:naming],
+    explanations: [
+      check: """
+      In an effort to encourage more accurate module naming practices, it is
+      sometimes useful to maintain a list of terms to avoid in module names.
 
-  @checkdoc """
-  In an effort to encourage more accurate module naming practices, it is
-  sometimes useful to maintain a list of terms to avoid in module names.
+      For example, if the list of terms to avoid is ["Manager", "Fetcher"]:
 
-  For example, if the list of terms to avoid is ["Manager", "Fetcher"]:
+          # preferred
 
-      # preferred
+          defmodule Accounts do
+          end
 
-      defmodule Accounts do
-      end
+          defmodule App.Networking do
+          end
 
-      defmodule App.Networking do
-      end
+          # NOT preferred
 
-      # NOT preferred
+          defmodule AccountManager do
+          end
 
-      defmodule AccountManager do
-      end
-
-      defmodule App.DataFetcher do
-      end
-  """
-  @explanation [check: @checkdoc]
-
-  use Credo.Check, base_priority: :low
+          defmodule App.DataFetcher do
+          end
+      """,
+      params: [
+        terms: "A list of terms to avoid"
+      ]
+    ],
+    param_defaults: [terms: []]
 
   alias Credo.Code
   alias Credo.Code.Name
 
   @doc false
   def run(source_file, params \\ []) do
-    terms = Keyword.get(params, :terms, [])
+    terms = Params.get(params, :terms, __MODULE__)
 
     issue_meta = IssueMeta.for(source_file, params)
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule CredoNaming.MixProject do
 
   defp deps do
     [
-      {:credo, "~> 1.0"},
+      {:credo, "~> 1.4"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "1.0.4", "d2214d4cc88c07f54004ffd5a2a27408208841be5eca9f5a72ce9e8e835f7ede", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "1.4.0", "92339d4cbadd1e88b5ee43d427b639b68a11071b6f73854e33638e30a0ea11f5", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1fd3b70dce216574ce3c18bdf510b57e7c4c85c2ec9cad4bff854abaf7e58658"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "8e24fc8ff9a50b9f557ff020d6c91a03cded7e59ac3e0eec8a27e771430c7d27"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
 }

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -240,4 +240,25 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
       end
     )
   end
+
+  test "it should report a violation with custom filename callback using {mod, fun}" do
+    defmodule Validator do
+      def validate(_filename, module_name, _opts) do
+        if module_name == "Foo.Bar" do
+          {false, ["lib/foo/bar_yes.ex"]}
+        else
+          {true, []}
+        end
+      end
+    end
+
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("lib/foo/bar.ex")
+    |> assert_issue(@described_check,
+      valid_filename_callback: {Validator, :validate}
+    )
+  end
 end


### PR DESCRIPTION
Well most of these features are actually from Credo 1.3.

We’re now using the `explanations` (1.3), `params_defaults` (1.3) and `tags` (1.4) options in the `use Credo.Check` API.

The only thing that needed refactoring is that since we have to declare default values for params at _compile time_ instead of _runtime_, the `valid_filename_callback` needs to support the `{mod, fun}` syntax in addition to the `&fun/3` syntax (for backward compatibility).

Closes #10 