### PR TITLE
Add hex.pm publish workflow on new tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: 22.x
+          elixir-version: 1.10.x
+      - run: mix hex.publish --yes


### PR DESCRIPTION
When a new tag is pushed, we should publish it on https://hex.pm/packages/credo_naming