### PR TITLE
feat: allow configuring apps_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ def valid_filename?(filename, module_name, opts), do: CredoNaming.Check.Consiste
 
 Instead of implementing your own `valid_filename_callback` function, you can use the `plugins` option to enforce a specific supported naming convention. For now, only `:phoenix` is supported.
 
+#### Setting `apps_path`
+
+In case you have an umbrella project and have set `apps_path` to something other than `apps`, you can set the `apps_path` option to the correct path.
+
+```elixir
+{CredoNaming.Check.Consistency.ModuleFilename, apps_path: "my_apps_path"}
+```
+
 ## Contributors
 
 - Rémi Prévost ([@remiprev](https://github.com/remiprev))

--- a/lib/credo_naming/check/consistency/module_filename.ex
+++ b/lib/credo_naming/check/consistency/module_filename.ex
@@ -36,14 +36,16 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
         plugins: "A list of atoms for applying plugin specific naming (ex: :phoenix)",
         excluded_paths: "A list of paths to exclude",
         acronyms: "A list of tuples that map a module term to its path version, eg. [{\"MyAppGraphQL\", \"myapp_graphql\"}]",
-        valid_filename_callback: "A function (either `&fun/3` or `{module, fun}`) that will be called on each filename with the name of the module it defines"
+        valid_filename_callback: "A function (either `&fun/3` or `{module, fun}`) that will be called on each filename with the name of the module it defines",
+        apps_path: "The path to the apps folder in umbrella projects"
       ]
     ],
     param_defaults: [
       plugins: [],
       excluded_paths: [],
       acronyms: [],
-      valid_filename_callback: {__MODULE__, :valid_filename?}
+      valid_filename_callback: {__MODULE__, :valid_filename?},
+      apps_path: "apps"
     ]
 
   alias Credo.Code
@@ -87,9 +89,11 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
   end
 
   @doc "Returns the root path of a file, with support for umbrella projects"
-  def root_path(filename) do
+  def root_path(filename, params) do
+    apps_path = Params.get(params, :apps_path, __MODULE__)
+
     case Path.split(filename) do
-      ["apps", app, root | _] -> Path.join(["apps", app, root])
+      [^apps_path, app, root | _] -> Path.join([apps_path, app, root])
       [root | _] -> root
     end
   end
@@ -149,7 +153,7 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
     acronyms = Params.get(params, :acronyms, __MODULE__)
     plugins = Params.get(params, :plugins, __MODULE__)
     extension = Path.extname(filename)
-    root_path = root_path(filename)
+    root_path = root_path(filename, params)
 
     base_module_paths =
       module_name

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -123,6 +123,15 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report a violation when apps_path is defined correctly" do
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("backend/abc/lib/foo/bar.ex")
+    |> refute_issues(@described_check, apps_path: "backend")
+  end
+
   test "it should NOT report violation for a file called stdin" do
     """
     defmodule Foo.Bar do
@@ -243,6 +252,15 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     """
     |> to_source_file("lib/foo/schemas/bar.ex")
     |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation when apps_path is defined incorrectly" do
+    """
+    defmodule Foo.Bar do
+    end
+    """
+    |> to_source_file("not_backend/abc/lib/foo/bar.ex")
+    |> assert_issue(@described_check, apps_path: "backend")
   end
 
   test "it should report a violation for missing PascalCase root module" do


### PR DESCRIPTION
## 📖 Description and reason

Allows setting `apps_path` to an arbitrary path.

Mix allows you to set `apps_path` to any directory, in our case we set it to `backend/` and credo_naming was not finding the correct root path.

## 👷 Work done

- changed `root_path` to be configured with `apps_path`
- updated the README with the new parameter

