### PR TITLE
One arity function in :plugins opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,11 @@ def valid_filename?(filename, module_name, opts), do: CredoNaming.Check.Consiste
 {CredoNaming.Check.Consistency.ModuleFilename, valid_filename_callback: &valid_filename/3}
 ```
 
-Instead of implementing your own `valid_filename_callback` function, you can use the `plugins` option to enforce a specific supported naming convention. For now, only `:phoenix` is supported.
+Instead of implementing your own `valid_filename_callback` function, you can use the `plugins` option to enforce a specific supported naming convention. This option accepts a list of: one arity function or plugin name (for now, only `:phoenix` is supported as a predefined plugin).
+
+```
+{CredoNaming.Check.Consistency.ModuleFilename, plugins: [:phoenix, &IO.inspect/1]}
+```
 
 #### Setting `apps_path`
 
@@ -160,6 +164,7 @@ In case you have an umbrella project and have set `apps_path` to something other
 - Felipe Duzzi ([@duzzifelipe](https://github.com/duzzifelipe))
 - Daniel Willeitner ([@D-Town44](https://github.com/D-Town44))
 - Daniel Reigada ([@DReigada](https://github.com/DReigada))
+- Pavel Tsiukhtsiayeu ([@paveltyk](https://github.com/paveltyk))
 
 ## License
 

--- a/lib/credo_naming/check/consistency/module_filename.ex
+++ b/lib/credo_naming/check/consistency/module_filename.ex
@@ -207,7 +207,10 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename do
 
   defp plugin_specific_names(paths, plugins) do
     Enum.reduce(plugins, paths, fn plugin, path_result ->
-      Plugins.module_for_name(plugin).transform_paths(path_result)
+      case Plugins.module_for_name(plugin) do
+        fun when is_function(fun) -> fun.(paths)
+        module when is_atom(module) -> module.transform_paths(path_result)
+      end
     end)
   end
 end

--- a/lib/credo_naming/check/consistency/module_filename/plugins.ex
+++ b/lib/credo_naming/check/consistency/module_filename/plugins.ex
@@ -4,5 +4,6 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename.Plugins do
   @callback transform_paths(paths :: list(list(atom()))) :: list(list(atom()))
 
   def module_for_name(:phoenix), do: Phoenix
+  def module_for_name(fun) when is_function(fun), do: fun
   def module_for_name(_), do: raise("Plugin not supported")
 end

--- a/test/credo_naming/check/consistency/module_filename/plugins_test.exs
+++ b/test/credo_naming/check/consistency/module_filename/plugins_test.exs
@@ -8,6 +8,11 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename.PluginsTest do
       assert Plugins.Phoenix == Plugins.module_for_name(:phoenix)
     end
 
+    test "should return one arity function for function" do
+      fun = Plugins.module_for_name(fn paths -> paths end)
+      assert 1 == :erlang.fun_info(fun)[:arity]
+    end
+
     test "should raise when plugin doesn't exist" do
       assert_raise RuntimeError, "Plugin not supported", fn ->
         Plugins.module_for_name(:an_ancient_bird)

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -180,6 +180,22 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     )
   end
 
+  test "it should NOT report a violation when path is valid for custom function plugin" do
+    plugin_fun = fn
+      ["foo_api", "bar_controller"] -> ["foo_api", "controllers", "bar_controller"]
+      other -> other
+    end
+
+    """
+    defmodule FooApi.BarController do
+    end
+    """
+    |> to_source_file("lib/foo_api/controllers/bar_controller.ex")
+    |> refute_issues(@described_check,
+      plugins: [plugin_fun]
+    )
+  end
+
   test "it should NOT report if excluded by regex" do
     """
     defmodule Bar do


### PR DESCRIPTION
## 📖 Description and reason

Currently, `:plugins` option supports only `:phoenix`. It would be nice to add some flexibility by supporting one arity function.

In my case the project folder structure does not match with the Phoenix naming convention, i.e. instead of `app_web` I have `app_api`. That prevents the predefined `:phoenix` plugin to do its' magic. This PR will allow for `plugins: [&MyApp.Credo.check_module_fIlename/1]`

## 👷 Work done

#### Tasks

- [x] Update tests
- [x] Update Readme

#### Additional notes

Consider passing module name in `:plugins` opt. This will follow the Open Closed principle, i.e. `plugins: [CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix]`

## 🎉 Result

Not needed

## 🦀 Dispatch

`#dispatch/elixir`
