### PR TITLE
Deprecate `:phoenix` atom as predefined plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ def valid_filename?(filename, module_name, opts), do: CredoNaming.Check.Consiste
 {CredoNaming.Check.Consistency.ModuleFilename, valid_filename_callback: &valid_filename/3}
 ```
 
-Instead of implementing your own `valid_filename_callback` function, you can use the `plugins` option to enforce a specific supported naming convention. This option accepts a list of: one arity function or plugin name (for now, only `:phoenix` is supported as a predefined plugin).
+Instead of implementing your own `valid_filename_callback` function, you can use the `plugins` option to enforce a specific supported naming convention. This option accepts a list of: one arity function or plugin name (for now, only `CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix` is supported as a predefined plugin).
 
-```
-{CredoNaming.Check.Consistency.ModuleFilename, plugins: [:phoenix, &IO.inspect/1]}
+```elixir
+{CredoNaming.Check.Consistency.ModuleFilename, plugins: [CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix, &IO.inspect/1]}
 ```
 
 #### Setting `apps_path`

--- a/lib/credo_naming/check/consistency/module_filename/plugins.ex
+++ b/lib/credo_naming/check/consistency/module_filename/plugins.ex
@@ -1,9 +1,16 @@
 defmodule CredoNaming.Check.Consistency.ModuleFilename.Plugins do
-  alias CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix
+  @plugins [
+    CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix
+  ]
 
   @callback transform_paths(paths :: list(list(atom()))) :: list(list(atom()))
 
-  def module_for_name(:phoenix), do: Phoenix
+  def module_for_name(:phoenix) do
+    IO.warn("Using `:phoenix` as a plugin is deprecated; use `CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix` instead.", Macro.Env.stacktrace(__ENV__))
+    CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix
+  end
+
+  def module_for_name(plugin) when plugin in @plugins, do: plugin
   def module_for_name(fun) when is_function(fun), do: fun
   def module_for_name(_), do: raise("Plugin not supported")
 end

--- a/lib/credo_naming/check/consistency/module_filename/plugins.ex
+++ b/lib/credo_naming/check/consistency/module_filename/plugins.ex
@@ -1,8 +1,4 @@
 defmodule CredoNaming.Check.Consistency.ModuleFilename.Plugins do
-  @plugins [
-    CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix
-  ]
-
   @callback transform_paths(paths :: list(list(atom()))) :: list(list(atom()))
 
   def module_for_name(:phoenix) do
@@ -10,7 +6,6 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename.Plugins do
     CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix
   end
 
-  def module_for_name(plugin) when plugin in @plugins, do: plugin
-  def module_for_name(fun) when is_function(fun), do: fun
+  def module_for_name(plugin) when is_atom(plugin) or is_function(plugin), do: plugin
   def module_for_name(_), do: raise("Plugin not supported")
 end

--- a/test/credo_naming/check/consistency/module_filename/plugins_test.exs
+++ b/test/credo_naming/check/consistency/module_filename/plugins_test.exs
@@ -8,6 +8,10 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename.PluginsTest do
       assert Plugins.Phoenix == Plugins.module_for_name(:phoenix)
     end
 
+    test "should return plugin for plugin in list" do
+      assert Plugins.Phoenix == Plugins.module_for_name(Plugins.Phoenix)
+    end
+
     test "should return one arity function for function" do
       fun = Plugins.module_for_name(fn paths -> paths end)
       assert 1 == :erlang.fun_info(fun)[:arity]

--- a/test/credo_naming/check/consistency/module_filename/plugins_test.exs
+++ b/test/credo_naming/check/consistency/module_filename/plugins_test.exs
@@ -19,7 +19,7 @@ defmodule CredoNaming.Check.Consistency.ModuleFilename.PluginsTest do
 
     test "should raise when plugin doesn't exist" do
       assert_raise RuntimeError, "Plugin not supported", fn ->
-        Plugins.module_for_name(:an_ancient_bird)
+        Plugins.module_for_name("an_ancient_bird")
       end
     end
   end

--- a/test/credo_naming/check/consistency/module_filename_test.exs
+++ b/test/credo_naming/check/consistency/module_filename_test.exs
@@ -176,7 +176,7 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     """
     |> to_source_file("lib/foo_web/controllers/bar_controller.ex")
     |> refute_issues(@described_check,
-      plugins: [:phoenix]
+      plugins: [CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix]
     )
   end
 
@@ -359,7 +359,7 @@ defmodule CredoNaming.Check.Consistency.ModuleFilenameTest do
     """
     |> to_source_file("lib/foo_web/controllers/some_another_controller.ex")
     |> assert_issue(@described_check,
-      plugins: [:phoenix]
+      plugins: [CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix]
     )
   end
 


### PR DESCRIPTION
## 📖 Description and reason

Following @paveltyk’s suggestion in #28, let’s favor the use of `CredoNaming.Check.Consistency.ModuleFilename.Plugins.Phoenix` as our predefined plugin instead of the opaque `:phoenix` atom.

`:phoenix` is still supported for backward-compatibility.

## 🦀 Dispatch

`#dispatch/elixir`
